### PR TITLE
make intercetor non-request scoped

### DIFF
--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -7,7 +7,7 @@ import { RequestInterceptor } from './request-interceptor/request-interceptor.se
 export class AppController {
   constructor(private readonly appService: AppService) { }
 
-  @UseInterceptors(RequestInterceptor)
+  // @UseInterceptors(RequestInterceptor)
   @Get()
   async getHello(): Promise<string> {
     return this.appService.getHello();

--- a/src/cats/cats.controller.ts
+++ b/src/cats/cats.controller.ts
@@ -7,7 +7,7 @@ export class CatsController {
 
   constructor(private readonly catsService: CatsService) { }
 
-  @UseInterceptors(RequestInterceptor)
+  // @UseInterceptors(RequestInterceptor)
   @Get()
   async getHello(): Promise<string> {
     return this.catsService.getCats();

--- a/src/dogs/dogs.controller.ts
+++ b/src/dogs/dogs.controller.ts
@@ -7,7 +7,7 @@ export class DogsController {
 
   constructor(private readonly dogsService: DogsService) { }
 
-  @UseInterceptors(RequestInterceptor)
+  // @UseInterceptors(RequestInterceptor)
   @Get()
   getHello(): string {
     return this.dogsService.getDogs();

--- a/src/request-interceptor/request-interceptor.module.ts
+++ b/src/request-interceptor/request-interceptor.module.ts
@@ -1,9 +1,16 @@
 import { Global, Module } from '@nestjs/common';
+import { APP_INTERCEPTOR } from '@nestjs/core';
 import { RequestInterceptor } from './request-interceptor.service';
 
 @Global()
 @Module({
-  providers: [RequestInterceptor],
-  exports: [RequestInterceptor]
+  providers: [
+    RequestInterceptor,
+    {
+      provide: APP_INTERCEPTOR,
+      useExisting: RequestInterceptor,
+    },
+  ],
+  exports: [RequestInterceptor],
 })
 export class RequestInterceptorModule {}

--- a/src/request-interceptor/request-interceptor.service.ts
+++ b/src/request-interceptor/request-interceptor.service.ts
@@ -3,7 +3,7 @@ import { Observable } from 'rxjs';
 
 let constructorCount = 0
 
-@Injectable({scope: Scope.REQUEST})
+@Injectable()
 export class RequestInterceptor implements NestInterceptor {
 
   private instanceId: number


### PR DESCRIPTION
Okay, so this is a really interesting problem you've shown, which is good, makes me think 😄. The idea here is to use the same interceptor everywhere, as there isn't much of a reason to have a request scoped interceptor, filter, guard, or pipe as they all get the incoming request (or part of the request), so the way to achieve this is to bind the `RequestInterceptor` as a normal provider and then also bind it as a global interceptor using the custom provider `APP_INTERCEPTOR` and making use of `useExisting` to ensure it's the same instance. By doing this, you're now able to use `modRef.get(RequestInterceptor, { strict: false })`. In my console log now, you can see the following

```
Instance 1 of HttpClientProxy created
{ id: 0.7358999917974127 }
Instance 1 of RequestInterceptor retrieved
Calling super.get(http://localhost:3000/cats)
Instance 2 of HttpClientProxy created
{ id: 0.6927755848246482 }
Instance 1 of RequestInterceptor retrieved
Calling super.get(http://localhost:3000/dogs)
```

This shows perfectly that there is no duplications of the `RequestInterceptor`, meaning that it's the same instance (though there's no worries about overwriting either due to node's single threaded model). If you have questions about this, feel free to ask, either here or Discord.